### PR TITLE
Disabled `static_lambda` rule

### DIFF
--- a/src/RuleSet/Php8.php
+++ b/src/RuleSet/Php8.php
@@ -65,7 +65,7 @@ class Php8 extends RulesetAbstract
         'simplified_if_return' => true,
         'standardize_increment' => true,
         'standardize_not_equals' => true,
-        'static_lambda' => true,
+        'static_lambda' => false,
         'switch_case_semicolon_to_colon' => true,
         'switch_continue_to_break' => true,
         'ternary_to_null_coalescing' => true,


### PR DESCRIPTION
It was potentially risky and broke Pest tests, which require non-static lambdas functions despite not implicitly referencing `$this`.